### PR TITLE
Update Devnet network url and program id.

### DIFF
--- a/src/store/reducer.ts
+++ b/src/store/reducer.ts
@@ -67,10 +67,10 @@ export const networks: Networks = {
   devnet: {
     // Cluster.
     label: "Devnet",
-    url: "https://devnet.solana.com",
+    url: "https://api.devnet.solana.com",
     explorerClusterSuffix: "devnet",
     multisigProgramId: new PublicKey(
-      "F3Uf5F61dmht1xuNNNkk3jnzj82TY56vVjVEhZALRkN"
+      "msigmtwzgXJHj2ext4XJjCDmpbcMuufFb5cHuwg6Xdt"
     ),
   },
   // Fill in with your local cluster addresses.


### PR DESCRIPTION
Fixes #6 

- Updates Devnet network url to `https://api.devnet.solana.com`.
- Updates Devnet program id to `msigmtwzgXJHj2ext4XJjCDmpbcMuufFb5cHuwg6Xdt`

As verifiable build is not yet supported on the Devnet, @armaniferrante please confirm that this program id corresponds to 0.7.0 of the multisig program.


